### PR TITLE
upgrade codecov/codecov-action to version 7.0.0

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,7 +63,7 @@ jobs:
 
       # consider ditching codecov - https://hynek.me/articles/ditch-codecov-python/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
v6.0.1 stopped working due to gpg verification issues on Codecov's side.

see https://github.com/codecov/codecov-action/issues/1955 and https://github.com/codecov/codecov-action/issues/1956